### PR TITLE
Use scanf to read POI records and query ranges

### DIFF
--- a/program.c
+++ b/program.c
@@ -86,7 +86,31 @@ void print_stage_header(int stage_num)
 void stage_one(int ids[], double coordinates[][DATA_DIM], int num_pois,
 			   double queries[][QUERY_BOUNDS], int num_queries)
 {
-	/* add code for stage 1 */
+	// Reading POI records: IDs and coordinates
+	for (int i = 0; i < num_pois; i++)
+	{
+		if (scanf("%d %lf %lf;", &ids[i], &coordinates[i][0], &coordinates[i][1]) != 3)
+		{
+			fprintf(stderr, "Error reading the POI data.\n");
+			exit(EXIT_FAILURE);
+		}
+		// Log the read POI for debugging purposes
+		fprintf(stderr, "Read POI #%d: ID=%d, x=%lf, y=%lf\n",
+				i, ids[i], coordinates[i][0], coordinates[i][1]);
+	}
+
+	// Reading the query ranges
+	for (int i = 0; i < num_queries; i++)
+	{
+		if (scanf("%lf %lf %lf %lf", &queries[i][0], &queries[i][1], &queries[i][2], &queries[i][3]) != 4)
+		{
+			fprintf(stderr, "Error reading the query data.\n");
+			exit(EXIT_FAILURE);
+		}
+		// Log the read query range for debugging purposes
+		fprintf(stderr, "Read query #%d: xlb=%lf, ylb=%lf, xub=%lf, yub=%lf\n",
+				i, queries[i][0], queries[i][1], queries[i][2], queries[i][3]);
+	}
 	/* print stage header */
 	print_stage_header(STAGE_NUM_ONE);
 }


### PR DESCRIPTION
The `scanf` function is employed to read in the formatted input for Points of Interest (POIs) and query ranges from `stdin`. 

For POIs, each `scanf` call is structured as `scanf("%d %lf %lf;", &ids[i], &coordinates[i][0], &coordinates[i][1])`. This means:
- `%d` captures an integer ID.
- Two `%lf` specifiers capture floating-point numbers for the x and y coordinates.
- A semicolon `;` is expected after each POI's y-coordinate as per the input format.

The condition `!= 3` ensures that three values (ID, x, and y) are read per POI. If not, an error message is printed to `stderr`, and the program exits.

For query ranges, the format `scanf("%lf %lf %lf %lf", &queries[i][0], &queries[i][1], &queries[i][2], &queries[i][3])` reads four floating-point numbers:
- The first two `%lf` specifiers capture the lower bounds of the query range (xlb, ylb).
- The next two `%lf` specifiers capture the upper bounds (xub, yub).

Similarly, `!= 4` checks that all four bounds are successfully read for each query range. If not, it triggers an error message and program termination.

The provided input file follows a specific pattern with POI data and query ranges separated by new lines, aligning with the structure expected by the `scanf` calls. The `fprintf` statements to `stderr` serve for debugging and will output the current POI or query range being read, which aids in verifying that input is being processed correctly.

---

here is the output of this PR:

```
assignment git:(read-text-files) clang -g -o program program.c  && ./program < test0.txt 

Read POI #0: ID=0, x=16.400000, y=69.400000
Read POI #1: ID=1, x=88.700000, y=13.300000
Read POI #2: ID=2, x=1.800000, y=98.800000
Read POI #3: ID=3, x=85.100000, y=96.100000
Read POI #4: ID=4, x=15.400000, y=22.300000
Read POI #5: ID=5, x=79.400000, y=61.900000
Read POI #6: ID=6, x=97.300000, y=68.100000
Read POI #7: ID=7, x=68.300000, y=9.300000
Read POI #8: ID=8, x=46.800000, y=43.300000
Read POI #9: ID=9, x=87.300000, y=42.300000
Read POI #10: ID=10, x=38.900000, y=46.500000
Read POI #11: ID=11, x=87.500000, y=34.600000
Read POI #12: ID=12, x=34.700000, y=40.900000
Read POI #13: ID=13, x=5.800000, y=37.400000
Read POI #14: ID=14, x=28.600000, y=55.800000
Read POI #15: ID=15, x=60.700000, y=70.400000
Read POI #16: ID=16, x=73.500000, y=63.100000
Read POI #17: ID=17, x=76.800000, y=92.100000
Read POI #18: ID=18, x=24.700000, y=4.400000
Read POI #19: ID=19, x=15.300000, y=46.400000
Read POI #20: ID=20, x=15.500000, y=51.700000
Read POI #21: ID=21, x=55.100000, y=99.500000
Read POI #22: ID=22, x=95.000000, y=13.200000
Read POI #23: ID=23, x=54.000000, y=97.100000
Read POI #24: ID=24, x=6.400000, y=37.800000
Read POI #25: ID=25, x=66.000000, y=16.400000
Read POI #26: ID=26, x=59.200000, y=88.200000
Read POI #27: ID=27, x=59.400000, y=81.600000
Read POI #28: ID=28, x=79.900000, y=68.500000
Read POI #29: ID=29, x=61.500000, y=0.500000
Read POI #30: ID=30, x=5.200000, y=69.100000
Read POI #31: ID=31, x=76.900000, y=74.900000
Read POI #32: ID=32, x=29.700000, y=50.300000
Read POI #33: ID=33, x=19.500000, y=78.500000
Read POI #34: ID=34, x=12.100000, y=83.400000
Read POI #35: ID=35, x=35.600000, y=1.200000
Read POI #36: ID=36, x=98.500000, y=97.500000
Read POI #37: ID=37, x=95.400000, y=78.400000
Read POI #38: ID=38, x=80.000000, y=32.700000
Read POI #39: ID=39, x=22.200000, y=73.500000
Read POI #40: ID=40, x=80.700000, y=42.000000
Read POI #41: ID=41, x=9.800000, y=10.900000
Read POI #42: ID=42, x=81.000000, y=93.400000
Read POI #43: ID=43, x=97.500000, y=30.400000
Read POI #44: ID=44, x=28.200000, y=44.100000
Read POI #45: ID=45, x=37.200000, y=97.000000
Read POI #46: ID=46, x=73.600000, y=9.800000
Read POI #47: ID=47, x=68.500000, y=17.900000
Read POI #48: ID=48, x=65.500000, y=50.000000
Read POI #49: ID=49, x=21.000000, y=48.000000
Read query #0: xlb=11.800000, ylb=3.500000, xub=53.500000, yub=28.500000
Read query #1: xlb=19.700000, ylb=58.600000, xub=47.100000, yub=66.800000
Read query #2: xlb=16.900000, ylb=67.600000, xub=74.800000, yub=93.400000
Read query #3: xlb=49.000000, ylb=70.700000, xub=54.900000, yub=74.900000
Read query #4: xlb=75.100000, ylb=25.100000, xub=99.900000, yub=49.900000
Stage 1
==========
Stage 2
==========
Stage 3
==========
Stage 4
==========
➜  assignment git:(read-text-files) 
```