### PR TITLE
Finish stage 1, add print_pois_in_query

### DIFF
--- a/program.c
+++ b/program.c
@@ -44,8 +44,36 @@ void stage_four(int ids[], double coordinates[][DATA_DIM], int curve_values[],
 				int num_pois, double queries[][QUERY_BOUNDS], int num_queries);
 
 int is_within_bounds(double point_x, double point_y,
-                     double xlb, double ylb, double xub, double yub) {
-    return (point_x >= xlb && point_x <= xub) && (point_y >= ylb && point_y <= yub);
+					 double xlb, double ylb, double xub, double yub)
+{
+	return (point_x >= xlb && point_x <= xub) && (point_y >= ylb && point_y <= yub);
+}
+
+/* Function to print POIs within the first query */
+void print_pois_in_query(int ids[], double coordinates[][DATA_DIM],
+						 double query_bounds[QUERY_BOUNDS])
+{
+	int first_poi_printed = 0; // Flag to track the first printed POI
+
+	for (int i = 0; i < DATA_SET_SIZE; i++)
+	{
+		if (is_within_bounds(coordinates[i][0], coordinates[i][1],
+							 query_bounds[0], query_bounds[1],
+							 query_bounds[2], query_bounds[3]))
+		{
+			if (first_poi_printed)
+			{
+				printf(" "); // Print a space before each subsequent POI ID
+			}
+			printf("%d", ids[i]);
+			first_poi_printed = 1;
+		}
+	}
+
+	if (!first_poi_printed)
+	{
+		printf(" none"); // Print "none" if no POIs are within the query bounds
+	}
 }
 
 /* add your own function prototypes here */
@@ -118,6 +146,11 @@ void stage_one(int ids[], double coordinates[][DATA_DIM], int num_pois,
 	}
 	/* print stage header */
 	print_stage_header(STAGE_NUM_ONE);
+
+	/* Call function to process and print POIs in the first query */
+	printf("POIs in Q0:");
+	print_pois_in_query(ids, coordinates, queries[0]);
+	printf("\n"); // Move to a new line after printing all relevant POIs
 }
 
 /* stage 2: sort and query POIs by the x-coordinates */


### PR DESCRIPTION
This pull request introduces the print_pois_in_query function, which enhances the application's capability to process and output Points of Interest (POIs) within a specified query range (Q0). The function iterates through all POIs, utilizes the previously implemented is_within_bounds to check if they lie within Q0, and prints their IDs in a space-separated format. If no POIs are found within Q0, it outputs "none," maintaining clarity and user-friendliness in scenarios with no matching POIs.

The addition of print_pois_in_query significantly improves the modularity of our code, centralizing the logic related to POI output within the first stage of our search algorithm. This makes the code easier to read, maintain, and test.

Example usage within the context of our assignment:

Given POI #4 with coordinates (15.4, 22.3) and Q0 with bounds (11.8, 3.5, 53.5, 28.5), print_pois_in_query will include POI #4 in the output as it satisfies the inclusion criteria of Q0.

The function ensures that the output format adheres to the assignment's specifications, beginning with POI IDs immediately following the "POIs in Q0:" label without leading spaces, and separating subsequent IDs with a single space.